### PR TITLE
Considere…

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 Aplicativo mobile com finalidade de encontrar de maneira automática a partir da localização próxima pessoas que estejam oferecendo ou buscando caronas para locais determinados pelos próprios usuários de forma que assegure que todos os usuários com acesso ao aplicativo seja estudante ativo em alguma universidade, podendo filtrar os usuários para juntar apenas estudantes de mesma universidade.
 O aplicativo tem como funcionalidade sugerir possíveis pessoas que estejam na rota para o local desejado e intermediar a comunicação entre elas.
 
+## Contexto (**apenas para ilustrar**)
+
+Sistema de gestão de carona para usuários acadêmicos visando redução de custos e tempo dos translados de/para a universidade. O sistema oferece acesso apenas a estudantes devidamente matriculados e ativos nas instituições de ensino cadastradas. Não é compartilhado endereço, telefone nem outros detalhes.... O horário das aulas,... muito pode ser feito, não é verdade?
+
 ## Alunos
 
 Gustavo Ribeiro de Oliveira (Matrícula: 201910881)


### PR DESCRIPTION
- Isso demanda um sistema no qual o aplicativo é apenas parte. Se o escopo é só o aplicativo, então deve ficar mais claro acima. Por exemplo, “Aplicativo para acesso ao serviço…”
- O termo “juntar” é informal. Aqui é um texto técnico, melhor seria “… que reúne…”
- Estão estabelecidas funcionalidade para o aplicativo que, em verdade, não é do aplicativo, mas de um sistema que reúne o aplicativo e outros componentes.